### PR TITLE
release: v0.1.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/zipcode2address-jp",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "This library provides method to get japanese address from zipcode.",
   "keywords": [
     "github",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "@commitlint/cli": "^12.1.4",
     "@commitlint/config-conventional": "^12.1.4",
     "@types/jest": "^26.0.23",
-    "@types/node": "^15.12.2",
-    "@typescript-eslint/eslint-plugin": "^4.26.1",
-    "@typescript-eslint/parser": "^4.26.1",
-    "eslint": "^7.28.0",
+    "@types/node": "^15.12.4",
+    "@typescript-eslint/eslint-plugin": "^4.27.0",
+    "@typescript-eslint/parser": "^4.27.0",
+    "eslint": "^7.29.0",
     "husky": "^6.0.0",
     "jest": "^27.0.4",
     "jest-circus": "^27.0.4",
@@ -54,7 +54,7 @@
     "nock": "^13.1.0",
     "pinst": "^2.1.6",
     "ts-jest": "^27.0.3",
-    "typescript": "^4.3.2"
+    "typescript": "^4.3.4"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,16 +22,16 @@
   integrity sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==
 
 "@babel/core@^7.1.0", "@babel/core@^7.7.2", "@babel/core@^7.7.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.5.tgz#d281f46a9905f07d1b3bf71ead54d9c7d89cb1e3"
-  integrity sha512-RN/AwP2DJmQTZSfiDaD+JQQ/J99KsIpOCfBE5pL+5jJSt7nI3nYGoAXZu+ffYSQ029NLs2DstZb+eR81uuARgg==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.6.tgz#e0814ec1a950032ff16c13a2721de39a8416fcab"
+  integrity sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==
   dependencies:
     "@babel/code-frame" "^7.14.5"
     "@babel/generator" "^7.14.5"
     "@babel/helper-compilation-targets" "^7.14.5"
     "@babel/helper-module-transforms" "^7.14.5"
-    "@babel/helpers" "^7.14.5"
-    "@babel/parser" "^7.14.5"
+    "@babel/helpers" "^7.14.6"
+    "@babel/parser" "^7.14.6"
     "@babel/template" "^7.14.5"
     "@babel/traverse" "^7.14.5"
     "@babel/types" "^7.14.5"
@@ -158,10 +158,10 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
   integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
 
-"@babel/helpers@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.14.5.tgz#4870f8d9a6fdbbd65e5674a3558b4ff7fef0d9b2"
-  integrity sha512-xtcWOuN9VL6nApgVHtq3PPcQv5qFBJzoSZzJ/2c0QK/IP/gxVcoWSNQwFEGvmbQsuS9rhYqjILDGGXcTkA705Q==
+"@babel/helpers@^7.14.6":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.14.6.tgz#5b58306b95f1b47e2a0199434fa8658fa6c21635"
+  integrity sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==
   dependencies:
     "@babel/template" "^7.14.5"
     "@babel/traverse" "^7.14.5"
@@ -176,10 +176,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.5", "@babel/parser@^7.7.2":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.5.tgz#4cd2f346261061b2518873ffecdf1612cb032829"
-  integrity sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.5", "@babel/parser@^7.14.6", "@babel/parser@^7.7.2":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.6.tgz#d85cc68ca3cac84eae384c06f032921f5227f4b2"
+  integrity sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -774,10 +774,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
-"@types/node@*", "@types/node@^15.12.2":
-  version "15.12.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.2.tgz#1f2b42c4be7156ff4a6f914b2fb03d05fa84e38d"
-  integrity sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==
+"@types/node@*", "@types/node@^15.12.4":
+  version "15.12.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.4.tgz#e1cf817d70a1e118e81922c4ff6683ce9d422e26"
+  integrity sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -818,13 +818,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.26.1.tgz#b9c7313321cb837e2bf8bebe7acc2220659e67d3"
-  integrity sha512-aoIusj/8CR+xDWmZxARivZjbMBQTT9dImUtdZ8tVCVRXgBUuuZyM5Of5A9D9arQPxbi/0rlJLcuArclz/rCMJw==
+"@typescript-eslint/eslint-plugin@^4.27.0":
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.27.0.tgz#0b7fc974e8bc9b2b5eb98ed51427b0be529b4ad0"
+  integrity sha512-DsLqxeUfLVNp3AO7PC3JyaddmEHTtI9qTSAs+RB6ja27QvIM0TA8Cizn1qcS6vOu+WDLFJzkwkgweiyFhssDdQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.26.1"
-    "@typescript-eslint/scope-manager" "4.26.1"
+    "@typescript-eslint/experimental-utils" "4.27.0"
+    "@typescript-eslint/scope-manager" "4.27.0"
     debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
     lodash "^4.17.21"
@@ -832,60 +832,60 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.26.1.tgz#a35980a2390da9232aa206b27f620eab66e94142"
-  integrity sha512-sQHBugRhrXzRCs9PaGg6rowie4i8s/iD/DpTB+EXte8OMDfdCG5TvO73XlO9Wc/zi0uyN4qOmX9hIjQEyhnbmQ==
+"@typescript-eslint/experimental-utils@4.27.0":
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.27.0.tgz#78192a616472d199f084eab8f10f962c0757cd1c"
+  integrity sha512-n5NlbnmzT2MXlyT+Y0Jf0gsmAQzCnQSWXKy4RGSXVStjDvS5we9IWbh7qRVKdGcxT0WYlgcCYUK/HRg7xFhvjQ==
   dependencies:
     "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.26.1"
-    "@typescript-eslint/types" "4.26.1"
-    "@typescript-eslint/typescript-estree" "4.26.1"
+    "@typescript-eslint/scope-manager" "4.27.0"
+    "@typescript-eslint/types" "4.27.0"
+    "@typescript-eslint/typescript-estree" "4.27.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.26.1.tgz#cecfdd5eb7a5c13aabce1c1cfd7fbafb5a0f1e8e"
-  integrity sha512-q7F3zSo/nU6YJpPJvQveVlIIzx9/wu75lr6oDbDzoeIRWxpoc/HQ43G4rmMoCc5my/3uSj2VEpg/D83LYZF5HQ==
+"@typescript-eslint/parser@^4.27.0":
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.27.0.tgz#85447e573364bce4c46c7f64abaa4985aadf5a94"
+  integrity sha512-XpbxL+M+gClmJcJ5kHnUpBGmlGdgNvy6cehgR6ufyxkEJMGP25tZKCaKyC0W/JVpuhU3VU1RBn7SYUPKSMqQvQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.26.1"
-    "@typescript-eslint/types" "4.26.1"
-    "@typescript-eslint/typescript-estree" "4.26.1"
+    "@typescript-eslint/scope-manager" "4.27.0"
+    "@typescript-eslint/types" "4.27.0"
+    "@typescript-eslint/typescript-estree" "4.27.0"
     debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.26.1.tgz#075a74a15ff33ee3a7ed33e5fce16ee86689f662"
-  integrity sha512-TW1X2p62FQ8Rlne+WEShyd7ac2LA6o27S9i131W4NwDSfyeVlQWhw8ylldNNS8JG6oJB9Ha9Xyc+IUcqipvheQ==
+"@typescript-eslint/scope-manager@4.27.0":
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.27.0.tgz#b0b1de2b35aaf7f532e89c8e81d0fa298cae327d"
+  integrity sha512-DY73jK6SEH6UDdzc6maF19AHQJBFVRf6fgAXHPXCGEmpqD4vYgPEzqpFz1lf/daSbOcMpPPj9tyXXDPW2XReAw==
   dependencies:
-    "@typescript-eslint/types" "4.26.1"
-    "@typescript-eslint/visitor-keys" "4.26.1"
+    "@typescript-eslint/types" "4.27.0"
+    "@typescript-eslint/visitor-keys" "4.27.0"
 
-"@typescript-eslint/types@4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.26.1.tgz#9e7c523f73c34b04a765e4167ca5650436ef1d38"
-  integrity sha512-STyMPxR3cS+LaNvS8yK15rb8Y0iL0tFXq0uyl6gY45glyI7w0CsyqyEXl/Fa0JlQy+pVANeK3sbwPneCbWE7yg==
+"@typescript-eslint/types@4.27.0":
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.27.0.tgz#712b408519ed699baff69086bc59cd2fc13df8d8"
+  integrity sha512-I4ps3SCPFCKclRcvnsVA/7sWzh7naaM/b4pBO2hVxnM3wrU51Lveybdw5WoIktU/V4KfXrTt94V9b065b/0+wA==
 
-"@typescript-eslint/typescript-estree@4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.26.1.tgz#b2ce2e789233d62283fae2c16baabd4f1dbc9633"
-  integrity sha512-l3ZXob+h0NQzz80lBGaykdScYaiEbFqznEs99uwzm8fPHhDjwaBFfQkjUC/slw6Sm7npFL8qrGEAMxcfBsBJUg==
+"@typescript-eslint/typescript-estree@4.27.0":
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.27.0.tgz#189a7b9f1d0717d5cccdcc17247692dedf7a09da"
+  integrity sha512-KH03GUsUj41sRLLEy2JHstnezgpS5VNhrJouRdmh6yNdQ+yl8w5LrSwBkExM+jWwCJa7Ct2c8yl8NdtNRyQO6g==
   dependencies:
-    "@typescript-eslint/types" "4.26.1"
-    "@typescript-eslint/visitor-keys" "4.26.1"
+    "@typescript-eslint/types" "4.27.0"
+    "@typescript-eslint/visitor-keys" "4.27.0"
     debug "^4.3.1"
     globby "^11.0.3"
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.26.1.tgz#0d55ea735cb0d8903b198017d6d4f518fdaac546"
-  integrity sha512-IGouNSSd+6x/fHtYRyLOM6/C+QxMDzWlDtN41ea+flWuSF9g02iqcIlX8wM53JkfljoIjP0U+yp7SiTS1onEkw==
+"@typescript-eslint/visitor-keys@4.27.0":
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.27.0.tgz#f56138b993ec822793e7ebcfac6ffdce0a60cb81"
+  integrity sha512-es0GRYNZp0ieckZ938cEANfEhsfHrzuLrePukLKtY3/KPXcq1Xd555Mno9/GOgXhKzn0QfkDLVgqWO3dGY80bg==
   dependencies:
-    "@typescript-eslint/types" "4.26.1"
+    "@typescript-eslint/types" "4.27.0"
     eslint-visitor-keys "^2.0.0"
 
 JSONStream@^1.0.4:
@@ -1193,9 +1193,9 @@ camelcase@^6.2.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001237"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz#4b7783661515b8e7151fc6376cfd97f0e427b9e5"
-  integrity sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw==
+  version "1.0.30001239"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz#66e8669985bb2cb84ccb10f68c25ce6dd3e4d2b8"
+  integrity sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -1353,9 +1353,9 @@ conventional-commits-parser@^3.0.0:
     trim-off-newlines "^1.0.0"
 
 convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
-  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.8.0.tgz#f3373c32d21b4d780dd8004514684fb791ca4369"
+  integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
   dependencies:
     safe-buffer "~5.1.1"
 
@@ -1591,10 +1591,10 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint@^7.28.0:
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.28.0.tgz#435aa17a0b82c13bb2be9d51408b617e49c1e820"
-  integrity sha512-UMfH0VSjP0G4p3EWirscJEQ/cHqnT/iuH6oNZOB94nBjWbMnhGEPxsZm1eyIW0C/9jLI0Fow4W5DXLjEI7mn1g==
+eslint@^7.29.0:
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.29.0.tgz#ee2a7648f2e729485e4d0bd6383ec1deabc8b3c0"
+  integrity sha512-82G/JToB9qIy/ArBzIWG9xvvwL3R86AlCjtGw+A29OMZDqhTybz/MByORSukGxeI+YPCR4coYyITKk8BFH9nDA==
   dependencies:
     "@babel/code-frame" "7.12.11"
     "@eslint/eslintrc" "^0.4.2"
@@ -1919,9 +1919,9 @@ globals@^13.6.0, globals@^13.9.0:
     type-fest "^0.20.2"
 
 globby@^11.0.3:
-  version "11.0.3"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
-  integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -3325,9 +3325,9 @@ redent@^3.0.0:
     strip-indent "^3.0.0"
 
 regexpp@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
-  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
+  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -3841,10 +3841,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+typescript@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
+  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
 universalify@^0.1.2:
   version "0.1.2"
@@ -3988,9 +3988,9 @@ write-file-atomic@^3.0.0:
     typedarray-to-buffer "^3.1.5"
 
 ws@^7.4.5:
-  version "7.4.6"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
-  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.0.tgz#0033bafea031fb9df041b2026fc72a571ca44691"
+  integrity sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update npm dependencies (f8b908c7d947b4d8218204bce1d00ca808a169e5)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/zipcode2address-jp/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>cli.js -u --packageFile package.json</em></summary>

```Shell
Using yarn
Upgrading /home/runner/work/zipcode2address-jp/zipcode2address-jp/package.json

 @types/node                       ^15.12.2  →  ^15.12.4     
 @typescript-eslint/eslint-plugin   ^4.26.1  →   ^4.27.0     
 @typescript-eslint/parser          ^4.26.1  →   ^4.27.0     
 eslint                             ^7.28.0  →   ^7.29.0     
 typescript                          ^4.3.2  →    ^4.3.4     

Run yarn install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.10
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.3.2: The platform "linux" is incompatible with this module.
info "fsevents@2.3.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
$ [ -n "$CI" ] || [ ! -f node_modules/.bin/husky ] || husky install
Done in 13.81s.
```



</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.10
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.3.2: The platform "linux" is incompatible with this module.
info "fsevents@2.3.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 352 new dependencies.
info Direct dependencies
├─ @commitlint/cli@12.1.4
├─ @commitlint/config-conventional@12.1.4
├─ @types/jest@26.0.23
├─ @typescript-eslint/eslint-plugin@4.27.0
├─ @typescript-eslint/parser@4.27.0
├─ axios@0.21.1
├─ eslint@7.29.0
├─ husky@6.0.0
├─ jest@27.0.4
├─ lint-staged@11.0.0
├─ nock@13.1.0
├─ pinst@2.1.6
├─ ts-jest@27.0.3
└─ typescript@4.3.4
info All dependencies
├─ @babel/compat-data@7.14.5
├─ @babel/core@7.14.6
├─ @babel/helper-compilation-targets@7.14.5
├─ @babel/helper-function-name@7.14.5
├─ @babel/helper-get-function-arity@7.14.5
├─ @babel/helper-hoist-variables@7.14.5
├─ @babel/helper-member-expression-to-functions@7.14.5
├─ @babel/helper-module-imports@7.14.5
├─ @babel/helper-module-transforms@7.14.5
├─ @babel/helper-optimise-call-expression@7.14.5
├─ @babel/helper-replace-supers@7.14.5
├─ @babel/helper-simple-access@7.14.5
├─ @babel/helper-validator-option@7.14.5
├─ @babel/helpers@7.14.6
├─ @babel/highlight@7.14.5
├─ @babel/plugin-syntax-async-generators@7.8.4
├─ @babel/plugin-syntax-bigint@7.8.3
├─ @babel/plugin-syntax-class-properties@7.12.13
├─ @babel/plugin-syntax-import-meta@7.10.4
├─ @babel/plugin-syntax-json-strings@7.8.3
├─ @babel/plugin-syntax-logical-assignment-operators@7.10.4
├─ @babel/plugin-syntax-nullish-coalescing-operator@7.8.3
├─ @babel/plugin-syntax-numeric-separator@7.10.4
├─ @babel/plugin-syntax-object-rest-spread@7.8.3
├─ @babel/plugin-syntax-optional-catch-binding@7.8.3
├─ @babel/plugin-syntax-optional-chaining@7.8.3
├─ @babel/plugin-syntax-top-level-await@7.14.5
├─ @babel/plugin-syntax-typescript@7.14.5
├─ @babel/template@7.14.5
├─ @bcoe/v8-coverage@0.2.3
├─ @commitlint/cli@12.1.4
├─ @commitlint/config-conventional@12.1.4
├─ @commitlint/ensure@12.1.4
├─ @commitlint/execute-rule@12.1.4
├─ @commitlint/format@12.1.4
├─ @commitlint/is-ignored@12.1.4
├─ @commitlint/lint@12.1.4
├─ @commitlint/load@12.1.4
├─ @commitlint/message@12.1.4
├─ @commitlint/parse@12.1.4
├─ @commitlint/read@12.1.4
├─ @commitlint/resolve-extends@12.1.4
├─ @commitlint/rules@12.1.4
├─ @commitlint/to-lines@12.1.4
├─ @commitlint/top-level@12.1.4
├─ @eslint/eslintrc@0.4.2
├─ @istanbuljs/load-nyc-config@1.1.0
├─ @jest/globals@27.0.3
├─ @jest/reporters@27.0.4
├─ @jest/test-sequencer@27.0.4
├─ @nodelib/fs.scandir@2.1.5
├─ @nodelib/fs.stat@2.0.5
├─ @nodelib/fs.walk@1.2.7
├─ @sinonjs/commons@1.8.3
├─ @sinonjs/fake-timers@7.1.2
├─ @tootallnate/once@1.1.2
├─ @types/babel__core@7.1.14
├─ @types/babel__generator@7.6.2
├─ @types/babel__template@7.4.0
├─ @types/babel__traverse@7.11.1
├─ @types/graceful-fs@4.1.5
├─ @types/istanbul-lib-coverage@2.0.3
├─ @types/istanbul-lib-report@3.0.0
├─ @types/jest@26.0.23
├─ @types/json-schema@7.0.7
├─ @types/minimist@1.2.1
├─ @types/normalize-package-data@2.4.0
├─ @types/parse-json@4.0.0
├─ @types/prettier@2.3.0
├─ @types/stack-utils@2.0.0
├─ @typescript-eslint/eslint-plugin@4.27.0
├─ @typescript-eslint/experimental-utils@4.27.0
├─ @typescript-eslint/parser@4.27.0
├─ abab@2.0.5
├─ acorn-globals@6.0.0
├─ acorn-jsx@5.3.1
├─ acorn-walk@7.2.0
├─ acorn@7.4.1
├─ aggregate-error@3.1.0
├─ ajv@6.12.6
├─ ansi-colors@4.1.1
├─ ansi-escapes@4.3.2
├─ anymatch@3.1.2
├─ argparse@1.0.10
├─ array-ify@1.0.0
├─ array-union@2.1.0
├─ arrify@1.0.1
├─ asynckit@0.4.0
├─ at-least-node@1.0.0
├─ axios@0.21.1
├─ babel-jest@27.0.2
├─ babel-plugin-jest-hoist@27.0.1
├─ babel-preset-jest@27.0.1
├─ balanced-match@1.0.2
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ browser-process-hrtime@1.0.0
├─ browserslist@4.16.6
├─ bs-logger@0.2.6
├─ bser@2.1.1
├─ buffer-from@1.1.1
├─ camelcase-keys@6.2.2
├─ caniuse-lite@1.0.30001239
├─ chalk@4.1.1
├─ char-regex@1.0.2
├─ ci-info@3.2.0
├─ cjs-module-lexer@1.2.1
├─ clean-stack@2.2.0
├─ cli-cursor@3.1.0
├─ cliui@7.0.4
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ combined-stream@1.0.8
├─ commander@7.2.0
├─ concat-map@0.0.1
├─ conventional-changelog-angular@5.0.12
├─ conventional-changelog-conventionalcommits@4.6.0
├─ conventional-commits-parser@3.2.1
├─ convert-source-map@1.8.0
├─ cross-spawn@7.0.3
├─ cssom@0.4.4
├─ cssstyle@2.3.0
├─ dargs@7.0.0
├─ data-urls@2.0.0
├─ decamelize-keys@1.1.0
├─ decamelize@1.2.0
├─ decimal.js@10.2.1
├─ deep-is@0.1.3
├─ deepmerge@4.2.2
├─ delayed-stream@1.0.0
├─ detect-newline@3.1.0
├─ diff-sequences@27.0.1
├─ dir-glob@3.0.1
├─ doctrine@3.0.0
├─ domexception@2.0.1
├─ dot-prop@5.3.0
├─ electron-to-chromium@1.3.752
├─ emoji-regex@8.0.0
├─ enquirer@2.3.6
├─ error-ex@1.3.2
├─ escape-string-regexp@4.0.0
├─ escodegen@2.0.0
├─ eslint-utils@2.1.0
├─ eslint@7.29.0
├─ espree@7.3.1
├─ esprima@4.0.1
├─ esquery@1.4.0
├─ esrecurse@4.3.0
├─ fast-glob@3.2.5
├─ fast-levenshtein@2.0.6
├─ fastq@1.11.0
├─ fb-watchman@2.0.1
├─ file-entry-cache@6.0.1
├─ fill-range@7.0.1
├─ flat-cache@3.0.4
├─ flatted@3.1.1
├─ follow-redirects@1.14.1
├─ form-data@3.0.1
├─ fromentries@1.3.2
├─ fs-extra@9.1.0
├─ fs.realpath@1.0.0
├─ function-bind@1.1.1
├─ gensync@1.0.0-beta.2
├─ get-caller-file@2.0.5
├─ get-own-enumerable-property-symbols@3.0.2
├─ get-package-type@0.1.0
├─ get-stream@6.0.1
├─ git-raw-commits@2.0.10
├─ glob-parent@5.1.2
├─ glob@7.1.7
├─ global-dirs@0.1.1
├─ globals@13.9.0
├─ globby@11.0.4
├─ hard-rejection@2.1.0
├─ has@1.0.3
├─ hosted-git-info@4.0.2
├─ html-encoding-sniffer@2.0.1
├─ html-escaper@2.0.2
├─ http-proxy-agent@4.0.1
├─ https-proxy-agent@5.0.0
├─ human-signals@2.1.0
├─ husky@6.0.0
├─ iconv-lite@0.4.24
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ ini@1.3.8
├─ is-arrayish@0.2.1
├─ is-core-module@2.4.0
├─ is-extglob@2.1.1
├─ is-glob@4.0.1
├─ is-number@7.0.0
├─ is-obj@1.0.1
├─ is-plain-obj@1.1.0
├─ is-potential-custom-element-name@1.0.1
├─ is-regexp@1.0.0
├─ is-stream@2.0.0
├─ is-text-path@1.0.1
├─ is-unicode-supported@0.1.0
├─ isexe@2.0.0
├─ istanbul-lib-instrument@4.0.3
├─ istanbul-lib-source-maps@4.0.0
├─ istanbul-reports@3.0.2
├─ jest-changed-files@27.0.2
├─ jest-cli@27.0.4
├─ jest-docblock@27.0.1
├─ jest-jasmine2@27.0.4
├─ jest-leak-detector@27.0.2
├─ jest-pnp-resolver@1.2.2
├─ jest-resolve-dependencies@27.0.4
├─ jest-serializer@27.0.1
├─ jest-util@27.0.2
├─ jest-watcher@27.0.2
├─ jest@27.0.4
├─ js-tokens@4.0.0
├─ jsdom@16.6.0
├─ jsesc@2.5.2
├─ json-parse-even-better-errors@2.3.1
├─ json-schema-traverse@0.4.1
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json-stringify-safe@5.0.1
├─ json5@2.2.0
├─ jsonfile@6.1.0
├─ jsonparse@1.3.1
├─ JSONStream@1.3.5
├─ kind-of@6.0.3
├─ kleur@3.0.3
├─ leven@3.1.0
├─ lines-and-columns@1.1.6
├─ lint-staged@11.0.0
├─ listr2@3.10.0
├─ locate-path@5.0.0
├─ lodash.clonedeep@4.5.0
├─ lodash.merge@4.6.2
├─ lodash.set@4.3.2
├─ lodash.truncate@4.4.2
├─ lodash@4.17.21
├─ log-symbols@4.1.0
├─ log-update@4.0.0
├─ make-dir@3.1.0
├─ make-error@1.3.6
├─ makeerror@1.0.11
├─ map-obj@1.0.1
├─ mime-db@1.48.0
├─ mime-types@2.1.31
├─ mimic-fn@2.1.0
├─ min-indent@1.0.1
├─ minimist-options@4.1.0
├─ minimist@1.2.5
├─ mkdirp@1.0.4
├─ ms@2.1.2
├─ nock@13.1.0
├─ node-int64@0.4.0
├─ node-modules-regexp@1.0.0
├─ node-releases@1.1.73
├─ normalize-package-data@3.0.2
├─ npm-run-path@4.0.1
├─ nwsapi@2.2.0
├─ onetime@5.1.2
├─ optionator@0.9.1
├─ p-each-series@2.2.0
├─ p-limit@2.3.0
├─ p-locate@4.1.0
├─ p-map@4.0.0
├─ p-try@2.2.0
├─ parent-module@1.0.1
├─ parse5@6.0.1
├─ path-is-absolute@1.0.1
├─ path-key@3.1.1
├─ path-parse@1.0.7
├─ picomatch@2.3.0
├─ pinst@2.1.6
├─ pirates@4.0.1
├─ pkg-dir@4.2.0
├─ please-upgrade-node@3.2.0
├─ progress@2.0.3
├─ prompts@2.4.1
├─ propagate@2.0.1
├─ psl@1.8.0
├─ queue-microtask@1.2.3
├─ quick-lru@4.0.1
├─ read-pkg-up@7.0.1
├─ read-pkg@5.2.0
├─ readable-stream@3.6.0
├─ redent@3.0.0
├─ require-directory@2.1.1
├─ require-from-string@2.0.2
├─ resolve-cwd@3.0.0
├─ resolve-global@1.0.0
├─ restore-cursor@3.1.0
├─ reusify@1.0.4
├─ rimraf@3.0.2
├─ run-parallel@1.2.0
├─ rxjs@6.6.7
├─ safe-buffer@5.1.2
├─ safer-buffer@2.1.2
├─ saxes@5.0.1
├─ semver-compare@1.0.0
├─ semver@7.3.5
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ sisteransi@1.0.5
├─ source-map-support@0.5.19
├─ source-map@0.6.1
├─ spdx-correct@3.1.1
├─ spdx-exceptions@2.3.0
├─ sprintf-js@1.0.3
├─ string_decoder@1.3.0
├─ string-argv@0.3.1
├─ stringify-object@3.3.0
├─ strip-bom@4.0.0
├─ strip-final-newline@2.0.0
├─ strip-indent@3.0.0
├─ strip-json-comments@3.1.1
├─ supports-color@7.2.0
├─ supports-hyperlinks@2.2.0
├─ symbol-tree@3.2.4
├─ table@6.7.1
├─ terminal-link@2.1.1
├─ test-exclude@6.0.0
├─ text-extensions@1.9.0
├─ text-table@0.2.0
├─ through@2.3.8
├─ tmpl@1.0.4
├─ to-fast-properties@2.0.0
├─ to-regex-range@5.0.1
├─ tough-cookie@4.0.0
├─ tr46@2.1.0
├─ trim-newlines@3.0.1
├─ trim-off-newlines@1.0.1
├─ ts-jest@27.0.3
├─ tslib@1.14.1
├─ type-detect@4.0.8
├─ type-fest@0.20.2
├─ typedarray-to-buffer@3.1.5
├─ typescript@4.3.4
├─ util-deprecate@1.0.2
├─ v8-compile-cache@2.3.0
├─ v8-to-istanbul@7.1.2
├─ w3c-hr-time@1.0.2
├─ w3c-xmlserializer@2.0.0
├─ walker@1.0.7
├─ whatwg-url@8.6.0
├─ which@2.0.2
├─ word-wrap@1.2.3
├─ write-file-atomic@3.0.3
├─ ws@7.5.0
├─ xmlchars@2.2.0
├─ y18n@5.0.8
├─ yallist@4.0.0
├─ yaml@1.10.2
├─ yargs-parser@20.2.7
└─ yocto-queue@0.1.0
Done in 6.65s.
```



</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.10
0 vulnerabilities found - Packages audited: 548
Done in 0.59s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)